### PR TITLE
Delete a Sticky

### DIFF
--- a/backend/controllers/stickiesController.js
+++ b/backend/controllers/stickiesController.js
@@ -52,3 +52,31 @@ export const addNewSticky = async (req, res) => {
     });
   }
 };
+
+export const deleteSticky = async (req, res) => {
+  const stickyId = req.params.stickyId;
+  if (!stickyId) {
+    return res
+      .status(401)
+      .json({
+        messagr: "Please refer to an ID that is valid to your sticky note",
+      });
+  }
+  try {
+    const deletedSticky = await prisma.sticky.delete({
+      where: { id: stickyId },
+    });
+    if (!deletedSticky) {
+    	return res.status(401).json({message: "We were not capable of deleting your sticky note. Please try to delete your sticky note again"})
+    }
+    if (deletedSticky) {
+    	return res.status(201).json({message:"Successfully deleted your sticky note"})
+    }
+  } catch (err) {
+    console.log(err);
+    return res.status(500).json({
+      message:
+        "I am terribly sorry, something went wrong on the server, please try to delete your sticky again",
+    });
+  }
+};

--- a/backend/routes/stickiesRouter.js
+++ b/backend/routes/stickiesRouter.js
@@ -9,5 +9,6 @@ const stickiesRouter = express.Router();
 
 stickiesRouter.get("/user/stickies", auth, getAllStickies);
 stickiesRouter.post("/add/sticky", auth, addNewSticky);
+stickiesRouter.delete("/delete/sticky/:stickyId", auth, deleteSticky);
 
 export default stickiesRouter;

--- a/src/components/UsernamePassLogin.jsx
+++ b/src/components/UsernamePassLogin.jsx
@@ -105,7 +105,7 @@ const UsernamePassLogin = () => {
       color: "bg-red-300",
       text: `Invalid ${!validUserName && "username"}, ${
         !validPassword && "password"
-      }. Please fill out the form registration for with valid credentials`,
+      }. Please fill out the form registration with valid credentials`,
       hasCancel: true,
       actions: [{ text: "close", func: () => setSystemNotif({ show: false }) }],
     };

--- a/src/utils/api.js
+++ b/src/utils/api.js
@@ -423,3 +423,10 @@ export const addNewSticky = (token, sticky) => {
   );
   return res;
 };
+
+export const deleteStickyNote = (token, stickyId) => {
+	const res = Axios.delete(`${productionUrl}/delete/sticky/${stickyId}`, {headers: {
+		Authorization: `Bearer ${token}`
+	}})
+	return res;
+}


### PR DESCRIPTION
## Description

Now a user can delete a sticky note from the application.

## What changed? 
### backend
1. Sticky notes route added for deleting the data.
2. A controller implemented for the actual deletion of data in the db. 
3. Error handling is thorough in the controller covering both server and prisma errors with appropriate responses to the client
4. Authentication is required for this route

### frontend
1. Simple updates to sticky UI when the element is first loaded into state. 
2. API route created and used for deleting the sticky note. 
3. Success notifications were implemented when the server response is appropriate 

## Unfinished 
1. Client side error handling

## Related Issues

There are no related issues with this PR

## Checklist

- [ X] I have reviewed my code.
- [X ] I have tested my changes.
- [X ] I have updated documentation if necessary.

## Screenshots 

No applicable screen shots for this PR
